### PR TITLE
Fix aligned operator new avoiding boost::make_shared

### DIFF
--- a/lsd_slam_core/src/SlamSystem.cpp
+++ b/lsd_slam_core/src/SlamSystem.cpp
@@ -831,7 +831,7 @@ void SlamSystem::gtDepthInit(uchar* image, float* depth, double timeStamp, int i
 
 	currentKeyFrameMutex.lock();
 
-	currentKeyFrame = std::make_shared<Frame>(id, width, height, K, timeStamp, image);
+	currentKeyFrame.reset(new Frame(id, width, height, K, timeStamp, image));
 	currentKeyFrame->setDepthFromGroundTruth(depth);
 
 	map->initializeFromGTDepth(currentKeyFrame.get());
@@ -861,7 +861,7 @@ void SlamSystem::randomInit(uchar* image, double timeStamp, int id)
 
 	currentKeyFrameMutex.lock();
 
-	currentKeyFrame = std::make_shared<Frame>(id, width, height, K, timeStamp, image);
+	currentKeyFrame.reset(new Frame(id, width, height, K, timeStamp, image));
 	map->initializeRandomly(currentKeyFrame.get());
 	keyFrameGraph->addFrame(currentKeyFrame.get());
 
@@ -887,7 +887,7 @@ void SlamSystem::randomInit(uchar* image, double timeStamp, int id)
 void SlamSystem::trackFrame(uchar* image, unsigned int frameID, bool blockUntilMapped, double timestamp)
 {
 	// Create new frame
-	std::shared_ptr<Frame> trackingNewFrame = std::make_shared<Frame>(frameID, width, height, K, timestamp, image);
+	std::shared_ptr<Frame> trackingNewFrame(new Frame(frameID, width, height, K, timestamp, image));
 
 	if(!trackingIsGood)
 	{


### PR DESCRIPTION
Avoids using boost::make_shared; this affects 32bit architectures.

Note that boost::make_shared ignores
EIGEN_MAKE_ALIGNED_OPERATOR_NEW

It's a know limitation; see:
http://lists.boost.org/boost-users/2010/03/57713.php
