### PR TITLE
isActive read in FrameMemory::activateFrame befor being init

### DIFF
--- a/lsd_slam_core/src/DataStructures/Frame.cpp
+++ b/lsd_slam_core/src/DataStructures/Frame.cpp
@@ -479,6 +479,8 @@ void Frame::initialize(int id, int width, int height, const Eigen::Matrix3f& K, 
 	edgeErrorSum = edgesNum = 1;
 
 	lastConstraintTrackedCamToWorld = Sim3();
+
+	isActive = false;
 }
 
 void Frame::setDepth_Allocate()


### PR DESCRIPTION
It seems the member isActive of class Frame is read in FrameMemory::activateFrame before being init.
I assume it should be init to false at first.
