### PR TITLE
missing EIGEN macro

### DIFF
--- a/lsd_slam_core/src/DataStructures/FramePoseStruct.h
+++ b/lsd_slam_core/src/DataStructures/FramePoseStruct.h
@@ -29,6 +29,8 @@ namespace lsd_slam
 class Frame;
 class FramePoseStruct {
 public:
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
 	FramePoseStruct(Frame* frame);
 	virtual ~FramePoseStruct();
 


### PR DESCRIPTION
Macro EIGEN_MAKE_ALIGNED_OPERATOR_NEW seems to be missing in class FramePoseStruct.

Needed because of the Frame\* frame member ?
