### PR TITLE
[readme] add missing cv-bridge dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For this you need to create a rosbuild workspace (if you don't have one yet), us
 
 Install system dependencies:
 
-    sudo apt-get install ros-indigo-libg2o liblapack-dev libblas-dev freeglut3-dev libqglviewer-dev
+    sudo apt-get install ros-indigo-libg2o ros-indigo-cv-bridge liblapack-dev libblas-dev freeglut3-dev libqglviewer-dev
 
 In your ROS package path, clone the repository:
 


### PR DESCRIPTION
got the following error while trying to build the package, installing `ros-indigo-cv-bridge` fixed it.

```
  [rospack] Error: package 'lsd_slam_viewer' depends on non-existent package 'cv_bridge' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update'
  Failed to invoke /opt/ros/indigo/bin/rospack deps-manifests lsd_slam_core

  [rospack] Error: package 'lsd_slam_core' depends on non-existent package 'cv_bridge' and rosdep claims that it is not a system dependency. Check the ROS_PACKAGE_PATH or try calling 'rosdep update'

```
