### PR TITLE
Replacing camera matrix with projection matrix as LSD Slam assumes recti...

### DIFF
--- a/lsd_slam_core/src/IOWrapper/ROS/ROSImageStreamThread.cpp
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSImageStreamThread.cpp
@@ -146,10 +146,10 @@ void ROSImageStreamThread::infoCb(const sensor_msgs::CameraInfoConstPtr info)
 {
 	if(!haveCalib)
 	{
-		fx_ = info->K[0];
-		fy_ = info->K[4];
-		cx_ = info->K[2];
-		cy_ = info->K[5];
+		fx_ = info->P[0];
+		fy_ = info->P[5];
+		cx_ = info->P[2];
+		cy_ = info->P[6];
 
 		width_ = info->width;
 		height_ = info->height;


### PR DESCRIPTION
...fied input images if camera_info is given as input.

When calibration is not provided by input file but by camera_info message, the input images are required to be rectified beforehand (e.g. by ROS image_proc). As a consequence, the correct intrinsiscs are stored in P and not K. 

Tested with LSD_machine.bag and live with one of our cams.
