### PR TITLE
Add support for standard ROS PoseStamped message

### DIFF
--- a/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.cpp
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.cpp
@@ -109,7 +109,6 @@ void ROSOutput3DWrapper::publishKeyframe(Frame* f)
 	}
 
 	keyframe_publisher.publish(fMsg);
-	publishPose(f);
 }
 
 void ROSOutput3DWrapper::publishTrackedFrame(Frame* kf)
@@ -134,6 +133,7 @@ void ROSOutput3DWrapper::publishTrackedFrame(Frame* kf)
 
 
 	liveframe_publisher.publish(fMsg);
+	publishPose(kf);
 }
 
 
@@ -176,7 +176,6 @@ void ROSOutput3DWrapper::publishPose(Frame* f)
 	Eigen::Vector3d pos = f->getScaledCamToWorld().translation();
 	Eigen::Quaterniond rot = f->getScaledCamToWorld().quaternion();
 
-	//TODO : check rotation and translation frames
 	pMsg.pose.position.x = pos[0];
 	pMsg.pose.position.y = pos[1];
 	pMsg.pose.position.z = pos[2];
@@ -192,8 +191,9 @@ void ROSOutput3DWrapper::publishPose(Frame* f)
 	pMsg.pose.orientation.z *= -1;
 	pMsg.pose.orientation.w *= -1;
 	}
-
-	//TODO : Add timestamped header, sequence, frame-id
+	
+	pMsg.header.stamp = ros::Time::now();
+	pMsg.header.frame_id = "world";	
 	
 	pose_publisher.publish(pMsg);
 	

--- a/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
@@ -77,6 +77,8 @@ public:
 
 	virtual void publishDebugInfo(Eigen::Matrix<float, 20, 1> data);
 
+	virtual void publishPose(Frame* f);
+
 
 	int publishLvl;
 	
@@ -92,6 +94,8 @@ private:
 	std::string graph_channel;
 	ros::Publisher graph_publisher;
 
+	std::string pose_channel;
+	ros::Publisher pose_publisher;
 
 	std::string debugInfo_channel;
 	ros::Publisher debugInfo_publisher;

--- a/lsd_slam_core/src/util/settings.cpp
+++ b/lsd_slam_core/src/util/settings.cpp
@@ -90,7 +90,7 @@ bool useAffineLightningEstimation = true;
 
 
 bool useFabMap = false;
-bool doSlam = true;
+bool doSlam = false;
 bool doKFReActivation = true;
 bool doMapping = true;
 

--- a/lsd_slam_core/src/util/settings.cpp
+++ b/lsd_slam_core/src/util/settings.cpp
@@ -90,7 +90,7 @@ bool useAffineLightningEstimation = true;
 
 
 bool useFabMap = false;
-bool doSlam = false;
+bool doSlam = true;
 bool doKFReActivation = true;
 bool doMapping = true;
 


### PR DESCRIPTION
This message can be used for direct vehicle state estimation or control, for people who are using LSD_SLAM onboard quadrotors, ground robots, etc. You may fuse this with metric sensor data like IMU, baro, etc. to get scaled metric measurements.

Coordinate frame : Z out of camera , Y down, X right. 
