### PR TITLE
Catkin build updates, some additions for MacOSX build

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,18 @@ Compile the two package by typing:
     rosmake lsd_slam
 
 
+Build  using **Catkin** tool from **catkin** branch:
 
+	sudo apt-get install ros-indigo-libg2o ros-indigo-cv-bridge liblapack-dev libblas-dev freeglut3-dev libqglviewer-dev libsuitesparse-dev ros-indigo-cmake-modules
+	mkdir -p ~/catkin_ws/src/
+	cd ~/catkin_ws/src/
+	git clone -b catkin https://github.com/tum-vision/lsd_slam.git
+	cd ~/catkin_ws
 
+Build order a bit strange as core package depends on one header from viewer package:
+
+	catkin_make --pkg lsd_slam_viewer
+	catkin_make --pkg lsd_slam_core
 
 
 ## 2.3 openFabMap for large loop-closure detection [optional]

--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -72,47 +72,9 @@ add_definitions("-DUSE_ROS")
 add_definitions("-DENABLE_SSE")
 
 # Also add some useful compiler flag
-#set(CMAKE_CXX_FLAGS
-#   "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
-#)
-
-# Notes from stackoverflow:
-# The short solution would be removing '-march=native' option (at least it worked for me).
-# Instead of falling back to the default SSE2, if you care about performance, 
-# you are better off with enabling optimization the instruction set closest to AVX 
-# which would be SSE4.2. So I'd rather replace -march=native with -msse4.2. 
-# Even better: -march=native -mno-avx. Or see the answer by @capisce
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -msse4.2 -Wall -D_REENTRANT --std=c++0x")
-
-# On Mac OSX it is not possible to build with at least clang shipped by Apple
-# my guess due to lack of some c++0x/C++11 features
-# However gcc unable to link against libraries built by clang
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	# SET (CMAKE_C_COMPILER             "/usr/bin/clang")
-	# SET (CMAKE_CXX_COMPILER             "/usr/bin/clang++")
-	#     SET (CMAKE_AR      "/usr/bin/llvm-ar")
-	#     SET (CMAKE_LINKER  "/usr/bin/llvm-ld")
-	#     SET (CMAKE_NM      "/usr/bin/llvm-nm")
-	#     SET (CMAKE_OBJDUMP "/usr/bin/llvm-objdump")
-	#     SET (CMAKE_RANLIB  "/usr/bin/llvm-ranlib")
-	# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
-	SET (CMAKE_C_COMPILER             "/usr/local/bin/gcc")
-	SET (CMAKE_CXX_COMPILER             "/usr/local/bin/g++")
-	SET (CMAKE_AR      "/usr/local/bin/ar")
-	SET (CMAKE_LINKER  "/usr/local/bin/ld")
-	SET (CMAKE_NM      "/usr/local/bin/nm")
-	SET (CMAKE_OBJDUMP "/usr/local/bin/objdump")
-	SET (CMAKE_RANLIB  "/usr/local/bin/ranlib")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -Wall -D_REENTRANT --std=c++0x")
-else()
-	# SSE flags
-	set(CMAKE_CXX_FLAGS
-	"${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
-	)
-endif()
-
-
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
+)
 
 # Set source files
 set(lsd_SOURCE_FILES
@@ -149,6 +111,7 @@ include_directories(
   include
   ${EIGEN_INCLUDE_DIR}
   ${EIGEN3_INCLUDE_DIR}
+  ${X11_INCLUDE_DIR}
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/thirdparty/Sophus
   ${CSPARSE_INCLUDE_DIR} #Has been set by SuiteParse
@@ -158,14 +121,14 @@ include_directories(
 
 # build shared library.
 add_library(lsdslam SHARED ${SOURCE_FILES})
-target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} ${CSPARSE_LIBRARY}) 
+target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} ${CSPARSE_LIBRARY} ${X11_LIBRARIES}) 
 #csparse cxsparse )
 #rosbuild_link_boost(lsdslam thread)
 
 
 # build live ros node
 add_executable(live_slam src/main_live_odometry.cpp)
-target_link_libraries(live_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES} ${X11_LIBRARIES} )
+target_link_libraries(live_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES})
 
 
 # build image node

--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -10,6 +10,8 @@ project(lsd_slam_core)
 set(CMAKE_BUILD_TYPE Release)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
+  #lsd_slam_viewer
   cv_bridge
   dynamic_reconfigure
   sensor_msgs
@@ -18,21 +20,41 @@ find_package(catkin REQUIRED COMPONENTS
   rosbag
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
 find_package(X11 REQUIRED)
 include(cmake/FindG2O.cmake)
 include(cmake/FindSuiteParse.cmake)
 
+#find csparse
+#FIND_PACKAGE(SuiteSparse)
+IF(CSPARSE_FOUND)
+MESSAGE(STATUS "CSPARSE FOUND")
+ELSE(CSPARSE_FOUND)
+MESSAGE(STATUS "CSPARSE NOT FOUND")
+ENDIF(CSPARSE_FOUND)
+
+#########################################################
+# FIND X11
+#########################################################
+find_package(X11)
+if(NOT X11_FOUND)
+	message(FATAL_ERROR "Failed to find X11")
+endif(NOT X11_FOUND)
+      
 message("-- CHOLMOD_INCLUDE_DIR : " ${CHOLMOD_INCLUDE_DIR})
 message("-- CSPARSE_INCLUDE_DIR : " ${CSPARSE_INCLUDE_DIR})
 message("-- G2O_INCLUDE_DIR : " ${G2O_INCLUDE_DIR})
+message("-- EIGEN3_INCLUDE_DIR : " ${EIGEN3_INCLUDE_DIR})
+message("-- EIGEN_INCLUDE_DIR : " ${EIGEN_INCLUDE_DIR})
+message("-- X11_LIBRARIES : " ${X11_LIBRARIES})
 
 # FabMap
 # uncomment this part to enable fabmap
-#add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap)
-#include_directories(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap/include)
-#add_definitions("-DHAVE_FABMAP")
-#set(FABMAP_LIB openFABMAP )
+add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap)
+include_directories(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap/include)
+add_definitions("-DHAVE_FABMAP")
+set(FABMAP_LIB openFABMAP )
 
 generate_dynamic_reconfigure_options(
   cfg/LSDDebugParams.cfg
@@ -42,7 +64,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
   LIBRARIES lsdslam
   DEPENDS Eigen SuiteSparse
-  CATKIN_DEPENDS libg2o 
+  CATKIN_DEPENDS libg2o #lsd_slam_viewer
 )
 
 # SSE flags
@@ -50,9 +72,47 @@ add_definitions("-DUSE_ROS")
 add_definitions("-DENABLE_SSE")
 
 # Also add some useful compiler flag
-set(CMAKE_CXX_FLAGS
-   "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
-) 
+#set(CMAKE_CXX_FLAGS
+#   "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
+#)
+
+# Notes from stackoverflow:
+# The short solution would be removing '-march=native' option (at least it worked for me).
+# Instead of falling back to the default SSE2, if you care about performance, 
+# you are better off with enabling optimization the instruction set closest to AVX 
+# which would be SSE4.2. So I'd rather replace -march=native with -msse4.2. 
+# Even better: -march=native -mno-avx. Or see the answer by @capisce
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -msse4.2 -Wall -D_REENTRANT --std=c++0x")
+
+# On Mac OSX it is not possible to build with at least clang shipped by Apple
+# my guess due to lack of some c++0x/C++11 features
+# However gcc unable to link against libraries built by clang
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	# SET (CMAKE_C_COMPILER             "/usr/bin/clang")
+	# SET (CMAKE_CXX_COMPILER             "/usr/bin/clang++")
+	#     SET (CMAKE_AR      "/usr/bin/llvm-ar")
+	#     SET (CMAKE_LINKER  "/usr/bin/llvm-ld")
+	#     SET (CMAKE_NM      "/usr/bin/llvm-nm")
+	#     SET (CMAKE_OBJDUMP "/usr/bin/llvm-objdump")
+	#     SET (CMAKE_RANLIB  "/usr/bin/llvm-ranlib")
+	# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
+	SET (CMAKE_C_COMPILER             "/usr/local/bin/gcc")
+	SET (CMAKE_CXX_COMPILER             "/usr/local/bin/g++")
+	SET (CMAKE_AR      "/usr/local/bin/ar")
+	SET (CMAKE_LINKER  "/usr/local/bin/ld")
+	SET (CMAKE_NM      "/usr/local/bin/nm")
+	SET (CMAKE_OBJDUMP "/usr/local/bin/objdump")
+	SET (CMAKE_RANLIB  "/usr/local/bin/ranlib")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -Wall -D_REENTRANT --std=c++0x")
+else()
+	# SSE flags
+	set(CMAKE_CXX_FLAGS
+	"${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
+	)
+endif()
+
+
 
 # Set source files
 set(lsd_SOURCE_FILES
@@ -87,6 +147,7 @@ set(SOURCE_FILES
 
 include_directories(
   include
+  ${EIGEN_INCLUDE_DIR}
   ${EIGEN3_INCLUDE_DIR}
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/thirdparty/Sophus
@@ -97,13 +158,14 @@ include_directories(
 
 # build shared library.
 add_library(lsdslam SHARED ${SOURCE_FILES})
-target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} csparse cxsparse )
+target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} ${CSPARSE_LIBRARY}) 
+#csparse cxsparse )
 #rosbuild_link_boost(lsdslam thread)
 
 
 # build live ros node
 add_executable(live_slam src/main_live_odometry.cpp)
-target_link_libraries(live_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES})
+target_link_libraries(live_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES} ${X11_LIBRARIES} )
 
 
 # build image node

--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -51,10 +51,15 @@ message("-- X11_LIBRARIES : " ${X11_LIBRARIES})
 
 # FabMap
 # uncomment this part to enable fabmap
-add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap)
-include_directories(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap/include)
-add_definitions("-DHAVE_FABMAP")
-set(FABMAP_LIB openFABMAP )
+if(WITH_FABMAP)
+  message("WITH_FABMAP: " ${WITH_FABMAP})
+  add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap)
+  include_directories(${PROJECT_SOURCE_DIR}/thirdparty/openFabMap/include)
+  add_definitions("-DHAVE_FABMAP")
+  set(FABMAP_LIB openFABMAP )
+else()
+  message("WITH_FABMAP: " ${WITH_FABMAP})
+endif(WITH_FABMAP)
 
 generate_dynamic_reconfigure_options(
   cfg/LSDDebugParams.cfg

--- a/lsd_slam_core/package.xml
+++ b/lsd_slam_core/package.xml
@@ -12,6 +12,7 @@
   <url>http://vision.in.tum.de/lsdslam</url>
   
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -22,6 +23,7 @@
   <build_depend>suitesparse</build_depend>
   <build_depend>libg2o</build_depend>
 
+  <run_depend>cmake_modules</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/lsd_slam_core/src/DataStructures/Frame.h
+++ b/lsd_slam_core/src/DataStructures/Frame.h
@@ -29,6 +29,11 @@
 #include "util/settings.h"
 
 
+#ifndef isnanf
+	#include <cmath>
+	#define isnanf (float)std::isnan
+#endif
+
 namespace lsd_slam
 {
 
@@ -161,7 +166,7 @@ public:
 
 	/** Multi-Map indicating for which other keyframes with which initialization tracking failed.*/
 	std::unordered_multimap< Frame*, Sim3, std::hash<Frame*>, std::equal_to<Frame*>,
-		Eigen::aligned_allocator< std::pair<const Frame*,Sim3> > > trackingFailed;
+		Eigen::aligned_allocator< std::pair<const Frame*,Sim3 > > > trackingFailed;
 
 
 	// flag set when depth is updated.

--- a/lsd_slam_core/src/DataStructures/Frame.h
+++ b/lsd_slam_core/src/DataStructures/Frame.h
@@ -166,7 +166,7 @@ public:
 
 	/** Multi-Map indicating for which other keyframes with which initialization tracking failed.*/
 	std::unordered_multimap< Frame*, Sim3, std::hash<Frame*>, std::equal_to<Frame*>,
-		Eigen::aligned_allocator< std::pair<const Frame*,Sim3 > > > trackingFailed;
+		Eigen::aligned_allocator< std::pair<Frame* const,Sim3 > > > trackingFailed;
 
 
 	// flag set when depth is updated.

--- a/lsd_slam_core/src/DepthEstimation/DepthMap.h
+++ b/lsd_slam_core/src/DepthEstimation/DepthMap.h
@@ -25,7 +25,10 @@
 #include "util/IndexThreadReduce.h"
 #include "util/SophusUtil.h"
 
-
+#ifndef isnanf
+	#include <cmath>
+	#define isnanf (float)std::isnan
+#endif
 
 namespace lsd_slam
 {

--- a/lsd_slam_core/src/GlobalMapping/KeyFrameGraph.h
+++ b/lsd_slam_core/src/GlobalMapping/KeyFrameGraph.h
@@ -180,7 +180,7 @@ private:
 	g2o::SparseOptimizer graph;
 	
 	std::vector< Frame*, Eigen::aligned_allocator<Frame*> > newKeyframesBuffer;
-	std::vector< KFConstraintStruct*, Eigen::aligned_allocator<FramePoseStruct*> > newEdgeBuffer;
+	std::vector< KFConstraintStruct* > newEdgeBuffer;
 
 
 	int nextEdgeId;

--- a/lsd_slam_core/src/IOWrapper/Timestamp.cpp
+++ b/lsd_slam_core/src/IOWrapper/Timestamp.cpp
@@ -29,7 +29,7 @@ namespace lsd_slam
 {
 
 
-const std::chrono::monotonic_clock::time_point Timestamp::startupTimePoint = std::chrono::monotonic_clock::now();
+const std::chrono::steady_clock::time_point Timestamp::startupTimePoint = std::chrono::steady_clock::now();
 boost::mutex Timestamp::localtimeMutex;
 
 Timestamp::Timestamp()
@@ -71,7 +71,7 @@ double Timestamp::secondsUntil(const Timestamp& other) const
 Timestamp Timestamp::now()
 {
 	Timestamp result;
-	result.timePoint = std::chrono::monotonic_clock::now();
+	result.timePoint = std::chrono::steady_clock::now();
 	result.systemTimePoint = std::chrono::system_clock::now();
 	return result;
 }

--- a/lsd_slam_core/src/IOWrapper/Timestamp.h
+++ b/lsd_slam_core/src/IOWrapper/Timestamp.h
@@ -75,10 +75,10 @@ public:
 	static Timestamp now();
 	
 private:
-	std::chrono::monotonic_clock::time_point timePoint;
+	std::chrono::steady_clock::time_point timePoint;
 	std::chrono::system_clock::time_point systemTimePoint;
 	
-	static const std::chrono::monotonic_clock::time_point startupTimePoint;
+	static const std::chrono::steady_clock::time_point startupTimePoint;
 	static boost::mutex localtimeMutex;
 
 	double externalStamp;

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -150,6 +150,7 @@ target_link_libraries(viewer ${QGLViewer_LIBRARIES}
 			     ${OPENGL_LIBRARIES}
 			     ${GLUT_LIBRARY}
 )
+add_dependencies(viewer lsd_slam_viewer_gencpp)
 
 #add_executable(videoStitch src/main_stitchVideos.cpp)
 #target_link_libraries(viewer ${QGLViewer_LIBRARIES}

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -9,11 +9,12 @@ project(lsd_slam_viewer)
 #  MinSizeRel : w/o debug symbols, w/ optimization, stripped binaries
 set(CMAKE_BUILD_TYPE Release)
 
-ADD_SUBDIRECTORY(${PROJECT_SOURCE_DIR}/thirdparty/Sophus)
+#ADD_SUBDIRECTORY(${PROJECT_SOURCE_DIR}/thirdparty/Sophus)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   cv_bridge
   dynamic_reconfigure
   sensor_msgs
@@ -23,6 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
   roslib
 )
 
+find_package(cmake_modules REQUIRED)
 find_package(OpenGL REQUIRED)
 set(QT_USE_QTOPENGL TRUE)
 set(QT_USE_QTXML TRUE)
@@ -31,15 +33,76 @@ find_package(Eigen REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 
+#########################################################
+# FIND GLUT
+#########################################################
+find_package(GLUT REQUIRED)
+include_directories(${GLUT_INCLUDE_DIRS})
+link_directories(${GLUT_LIBRARY_DIRS})
+add_definitions(${GLUT_DEFINITIONS})
+if(NOT GLUT_FOUND)
+    message(ERROR " GLUT not found!")
+endif(NOT GLUT_FOUND)
+
+#########################################################
+# FIND OPENGL
+#########################################################
+find_package(OpenGL REQUIRED)
+include_directories(${OpenGL_INCLUDE_DIRS})
+link_directories(${OpenGL_LIBRARY_DIRS})
+add_definitions(${OpenGL_DEFINITIONS})
+if(NOT OPENGL_FOUND)
+    message(ERROR " OPENGL not found!")
+endif(NOT OPENGL_FOUND)
+
+#########################################################
+# FIND X11
+#########################################################
+find_package(X11)
+if(NOT X11_FOUND)
+	message(FATAL_ERROR "Failed to find X11")
+endif(NOT X11_FOUND)
+
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	include_directories(/usr/X11R6/include/)
+	link_directories(/usr/X11R6/lib)
+	SET(EXTRA_LIBS GL X11 GLU glut)
+	#target_link_libraries(main ${EXTRA_LIBS})
+#else()
+#	SET(EXTRA_LIBS GL glut GLU)
+endif()
+
+
+message("-- EIGEN3_INCLUDE_DIR : " ${EIGEN3_INCLUDE_DIR})
+message("-- EIGEN_INCLUDE_DIR : " ${EIGEN_INCLUDE_DIR})
+message("-- X11_LIBRARIES : " ${X11_LIBRARIES})
+
 include_directories(${QGLVIEWER_INCLUDE_DIR}
 		    ${catkin_INCLUDE_DIRS} 
 		    ${EIGEN_INCLUDE_DIR}
 		    ${QT_INCLUDES} )
 
-# SSE flags
-set(CMAKE_CXX_FLAGS
-   "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
-)
+
+# On Mac OSX it is not possible to build with at least clang shipped by Apple
+# my guess due to lack of some C++11 features
+# However gcc unable to link against libraries built by clang
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	SET (CMAKE_C_COMPILER             "/usr/local/bin/gcc")
+	SET (CMAKE_CXX_COMPILER             "/usr/local/bin/g++")
+	SET (CMAKE_AR      "/usr/local/bin/ar")
+	SET (CMAKE_LINKER  "/usr/local/bin/ld")
+	SET (CMAKE_NM      "/usr/local/bin/nm")
+	SET (CMAKE_OBJDUMP "/usr/local/bin/objdump")
+	SET (CMAKE_RANLIB  "/usr/local/bin/ranlib")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -Wall -D_REENTRANT --std=c++0x")
+else()
+	# SSE flags
+	set(CMAKE_CXX_FLAGS
+	"${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
+	)
+endif()
 
 add_message_files(DIRECTORY msg FILES keyframeMsg.msg keyframeGraphMsg.msg)
 generate_messages(DEPENDENCIES)
@@ -48,6 +111,26 @@ generate_dynamic_reconfigure_options(
   cfg/LSDSLAMViewerParams.cfg
 )
 
+catkin_package(
+#INCLUDE_DIRS include
+LIBRARIES ${PROJECT_NAME}
+CATKIN_DEPENDS
+  cmake_modules
+  cv_bridge
+  dynamic_reconfigure
+  sensor_msgs
+  roscpp
+  rosbag
+  roslib
+DEPENDS
+  cmake_modules
+  cv_bridge
+  dynamic_reconfigure
+  sensor_msgs
+  roscpp
+  rosbag
+  roslib
+)
 
 # Sources files
 set(SOURCE_FILES         
@@ -64,6 +147,7 @@ set(HEADER_FILES
   src/settings.h
 )
 
+
 include_directories(
   ${PROJECT_SOURCE_DIR}/thirdparty/Sophus
 )  
@@ -74,8 +158,11 @@ target_link_libraries(viewer ${QGLViewer_LIBRARIES}
 			     ${catkin_LIBRARIES}
 			     ${Boost_LIBRARIES}
 			     ${QT_LIBRARIES}
-			     GL glut GLU
-		     )
+			     ${X11_LIBRARIES}
+			     ${EXTRA_LIBS}
+			     ${OPENGL_LIBRARIES}
+			     ${GLUT_LIBRARY}
+)
 
 #add_executable(videoStitch src/main_stitchVideos.cpp)
 #target_link_libraries(viewer ${QGLViewer_LIBRARIES}

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -84,25 +84,12 @@ include_directories(${QGLVIEWER_INCLUDE_DIR}
 		    ${QT_INCLUDES} )
 
 
-# On Mac OSX it is not possible to build with at least clang shipped by Apple
-# my guess due to lack of some C++11 features
-# However gcc unable to link against libraries built by clang
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	SET (CMAKE_C_COMPILER             "/usr/local/bin/gcc")
-	SET (CMAKE_CXX_COMPILER             "/usr/local/bin/g++")
-	SET (CMAKE_AR      "/usr/local/bin/ar")
-	SET (CMAKE_LINKER  "/usr/local/bin/ld")
-	SET (CMAKE_NM      "/usr/local/bin/nm")
-	SET (CMAKE_OBJDUMP "/usr/local/bin/objdump")
-	SET (CMAKE_RANLIB  "/usr/local/bin/ranlib")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -Wall -D_REENTRANT --std=c++0x")
-else()
-	# SSE flags
-	set(CMAKE_CXX_FLAGS
-	"${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
-	)
-endif()
+
+# SSE flags
+set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -march=native -Wall -std=c++0x"
+)
+
 
 add_message_files(DIRECTORY msg FILES keyframeMsg.msg keyframeGraphMsg.msg)
 generate_messages(DEPENDENCIES)

--- a/lsd_slam_viewer/package.xml
+++ b/lsd_slam_viewer/package.xml
@@ -12,6 +12,7 @@
   <url>http://vision.in.tum.de/lsdslam</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -20,6 +21,7 @@
   <build_depend>rosbag</build_depend>
   <build_depend>message_generation</build_depend>
 
+  <run_depend>cmake_modules</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>sensor_msgs</run_depend>

--- a/lsd_slam_viewer/src/KeyFrameDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameDisplay.cpp
@@ -24,9 +24,15 @@
 #include <stdio.h>
 #include "settings.h"
 
-#include <GL/glx.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+#ifdef __MACH__
+	//#include <GL/glx.h>
+	#include <GL/gl.h>
+	#include <GL/glu.h>
+#else
+	#include <GL/glx.h>
+	#include <GL/gl.h>
+	#include <GL/glu.h>
+#endif
 
 #include "opencv2/opencv.hpp"
 

--- a/lsd_slam_viewer/src/PointCloudViewer.cpp
+++ b/lsd_slam_viewer/src/PointCloudViewer.cpp
@@ -29,10 +29,15 @@
 #include <zlib.h>
 #include <iostream>
 
-
-#include <GL/glx.h>
-#include <GL/gl.h>
-#include <GL/glu.h>
+#ifdef __MACH__
+	//#include <GL/glx.h>
+	#include <GL/gl.h>
+	#include <GL/glu.h>
+#else
+	#include <GL/glx.h>
+	#include <GL/gl.h>
+	#include <GL/glu.h>
+#endif
 
 #include "QGLViewer/manipulatedCameraFrame.h"
 

--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -55,9 +55,14 @@ void dynConfCb(lsd_slam_viewer::LSDSLAMViewerParamsConfig &config, uint32_t leve
 	showCurrentCamera = config.showCurrentCamera;
 	showCurrentPointcloud = config.showCurrentPointcloud;
 
-
+#ifdef __MACH__
+	scaledDepthVarTH = __exp10( config.scaledDepthVarTH );
+	absDepthVarTH = __exp10( config.absDepthVarTH );
+#else
 	scaledDepthVarTH = exp10( config.scaledDepthVarTH );
-	absDepthVarTH = exp10( config.absDepthVarTH );
+	absDepthVarTH = exp10( config.absDepthVarTH );	
+#endif
+	
 	minNearSupport = config.minNearSupport;
 	sparsifyFactor = config.sparsifyFactor;
 	cutFirstNKf = config.cutFirstNKf;


### PR DESCRIPTION
I tried to make as less intrusion in code as possible (at least no changes in algorithm code), however CMake rules have a lot of changes to make build possible.

Updated package dependencies and build rules:
- Added `cmake_modules` ros package to fulfill `Eigen` dependency, etc.
- Added cmake `find_package` rule for GL, X11, etc. Hence removed hardcoded library names/paths. 
- Added toolchain choice if block for MacOSX and some specific CC and CXX compiler flags

Update sources for platform dependent functions:
- mostly fixes for MacOSX build (`__exp10`, `isnanf`)
- replaced `std::chrono::monotonic_clock` with `std::chrono::steady_clock`

Add notes on catkin build:

Main difference seems to be `ros-indigo-cmake-modules` dependency. For MacOSX build is still not possible, due to clang C++ features coverage and gcc-clang incompatibilities (gcc build code but fails to link to libs built by clang, e.g. roslib, opencv). And it will still need a long howto about ros/brew/mac.
