### PR TITLE
Issue Fix 50

### DIFF
--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -152,6 +152,8 @@ void rosFileLoop( int argc, char** argv )
 int main( int argc, char** argv )
 {
 
+	int i;
+	int containsBagFile = false;
 
 	printf("Started QApplication thread\n");
 	// Read command lines arguments.
@@ -173,7 +175,13 @@ int main( int argc, char** argv )
 
 	boost::thread rosThread;
 
-	if(argc > 1)
+	for (i=1; i< argc; i++) {
+		if(strstr(argv[i], ".bag") != NULL) {
+			containsBagFile = true;
+		}
+ 	}
+
+    if(containsBagFile == true)
 	{
 		rosThread = boost::thread(rosFileLoop, argc, argv);
 	}

--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -153,10 +153,10 @@ int main( int argc, char** argv )
 {
 
 	int i;
-	int containsBagFile = false;
+    bool containsBagFile = false;
 
 	printf("Started QApplication thread\n");
-	// Read command lines arguments.
+    // Read command lines arguments.
 	QApplication application(argc,argv);
 
 	// Instantiate the viewer.


### PR DESCRIPTION
This closed ticket describes an launcher error if lsd slam viewer will
be launched in an roslaunch file https://github.com/tum-
vision/lsd_slam/issues/55.

I wrote an fix for this in the main_viewer.cpp how checks if an bag file
is containing in arguments and load the rosfileloop or otherwise an
rosThreadLoop. Now all roslaunch files should be working.
