### PR TITLE
Fixed catkin make issue about eigen-config and DSO missing issues.

### DIFF
--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   rosbag
 )
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(X11 REQUIRED)
 include(cmake/FindG2O.cmake)
 include(cmake/FindSuiteParse.cmake)
@@ -41,8 +41,8 @@ generate_dynamic_reconfigure_options(
 
 catkin_package(
   LIBRARIES lsdslam
-  DEPENDS Eigen SuiteSparse
-  CATKIN_DEPENDS libg2o 
+  DEPENDS Eigen3 SuiteSparse
+  CATKIN_DEPENDS libg2o
 )
 
 # SSE flags
@@ -97,7 +97,7 @@ include_directories(
 
 # build shared library.
 add_library(lsdslam SHARED ${SOURCE_FILES})
-target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} csparse cxsparse )
+target_link_libraries(lsdslam ${FABMAP_LIB} ${G2O_LIBRARIES} ${catkin_LIBRARIES} csparse cxsparse X11)
 #rosbuild_link_boost(lsdslam thread)
 
 

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -27,13 +27,13 @@ find_package(OpenGL REQUIRED)
 set(QT_USE_QTOPENGL TRUE)
 set(QT_USE_QTXML TRUE)
 find_package(QGLViewer REQUIRED)
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 
 include_directories(${QGLVIEWER_INCLUDE_DIR}
 		    ${catkin_INCLUDE_DIRS} 
-		    ${EIGEN_INCLUDE_DIR}
+		    ${EIGEN3_INCLUDE_DIR}
 		    ${QT_INCLUDES} )
 
 # SSE flags


### PR DESCRIPTION
In ros-indigo system, I could not find eigen config file, so I changed Eigen to Eigen3. Also, X11 should be included as target link library. This fix DSO missing error.

After these two modification, compile is now successful. 
