### PR TITLE
Fixed compilation errors with ros-lunar + ubuntu 16.04

### DIFF
--- a/lsd_slam_core/cfg/LSDDebugParams.cfg
+++ b/lsd_slam_core/cfg/LSDDebugParams.cfg
@@ -8,8 +8,8 @@ from dynamic_reconfigure.parameter_generator import *
 
 gen = ParameterGenerator()
 
-gen.add("plotStereoImages", bool_t, 0, "Plot Searched Stereo Lines, and color-coded stereo-results. Nice Visualization of what's going on, however drastically decreases mapping speed.", False)
-gen.add("plotTracking", bool_t, 0, "Plot final tracking residual. Nice Visualization of what's going on, however drastically decreases tracking speed.", False)
+gen.add("plotStereoImages", bool_t, 0, "Plot Searched Stereo Lines, and color-coded stereo-results. Nice Visualization of whats going on, however drastically decreases mapping speed.", False)
+gen.add("plotTracking", bool_t, 0, "Plot final tracking residual. Nice Visualization of whats going on, however drastically decreases tracking speed.", False)
 
 
 #debug parameters
@@ -45,7 +45,7 @@ gen.add("printConstraintSearchInfo", bool_t, 0, "print lots of debug information
 gen.add("printOptimizationInfo", bool_t, 0, "print lots of debug information", False)
 gen.add("printRelocalizationInfo", bool_t, 0, "print lots of debug information", False)
 
-gen.add("continuousPCOutput", bool_t, 0, "Publish Current Keyframe's Pointcloud after each update, to be seen in the viewer. Nice Visualization, however bad for performance and bandwith. ", False)
+gen.add("continuousPCOutput", bool_t, 0, "Publish Current Keyframes Pointcloud after each update, to be seen in the viewer. Nice Visualization, however bad for performance and bandwith. ", False)
 
 
 # result save control

--- a/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
+++ b/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
@@ -17,11 +17,11 @@ gen.add("showCurrentPointcloud", bool_t, 0, "Toggle Drawing of the latest pointc
 
 gen.add("pointTesselation", double_t, 0, "Size of Points", 1, 0.0, 5)
 gen.add("lineTesselation", double_t, 0, "Width of Lines", 1, 0.0, 5)
-gen.add("scaledDepthVarTH", double_t, 0, "log10 of threshold on point's variance, in the respective keyframe's scale. ", -3, -10, 1)
-gen.add("absDepthVarTH", double_t, 0, "log10 of threshold on point's variance, in absolute scale.", -1, -10, 1)
+gen.add("scaledDepthVarTH", double_t, 0, "log10 of threshold on points variance, in the respective keyframes scale. ", -3, -10, 1)
+gen.add("absDepthVarTH", double_t, 0, "log10 of threshold on points variance, in absolute scale.", -1, -10, 1)
 gen.add("minNearSupport", int_t, 0, "only plot points that have #minNearSupport similar neighbours (higher values remove outliers)", 7, 0, 9)
 
-gen.add("cutFirstNKf", int_t, 0, "do not display the first #cutFirstNKf keyframe's pointclouds, to remove artifacts left-over from the random initialization.", 5, 0, 100)
+gen.add("cutFirstNKf", int_t, 0, "do not display the first #cutFirstNKf keyframes pointclouds, to remove artifacts left-over from the random initialization.", 5, 0, 100)
 
 gen.add("sparsifyFactor", int_t, 0, "only plot one out of #sparsifyFactor points, selected at random. Use this to significantly speed up rendering for large maps.", 1, 1, 100)
 

--- a/lsd_slam_viewer/src/KeyFrameDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameDisplay.cpp
@@ -28,8 +28,6 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 
-#include "opencv2/opencv.hpp"
-
 #include "ros/package.h"
 
 KeyFrameDisplay::KeyFrameDisplay()

--- a/lsd_slam_viewer/src/PointCloudViewer.cpp
+++ b/lsd_slam_viewer/src/PointCloudViewer.cpp
@@ -323,7 +323,7 @@ void PointCloudViewer::keyPressEvent(QKeyEvent *e)
     	  meddleMutex.lock();
 
 
-    	  float x,y,z;
+    	  qreal x,y,z;
     	  camera()->frame()->getPosition(x,y,z);
     	  animationList.push_back(AnimationObject(false, lastAnimTime, 2, qglviewer::Frame(qglviewer::Vec(0,0,0), camera()->frame()->orientation())));
     	  animationList.back().frame.setPosition(x,y,z);

--- a/lsd_slam_viewer/src/PointCloudViewer.h
+++ b/lsd_slam_viewer/src/PointCloudViewer.h
@@ -23,6 +23,7 @@
 //#define GL3_PROTOTYPES 1
 //#include <GL/glew.h>
 
+#include "QtGlobal"
 #include "QGLViewer/qglviewer.h"
 #include <vector>
 #include "boost/thread.hpp"
@@ -132,7 +133,7 @@ public:
 		int showCurrentCam_i = showCurrentCam;
 		int isFix_i = isFix;
 
-		float x,y,z;
+		qreal x,y,z;
 		frame.getPosition(x,y,z);
 
     	snprintf(buf, 1000, "Animation: %d at %lf (dur %lf) S: %f %f %d %d %d %d %d Frame: %lf %lf %lf %lf %f %f %f %d",


### PR DESCRIPTION
1. ROS lunar does not like quotes in config descriptions
2. QtFrame->getPosition needs the exact same type.
3. OpenCV is not being used and including header causes issue opencv/opencv/issues/7113
