### PR TITLE
Change ' to ` to avoid errors

### DIFF
--- a/lsd_slam_core/cfg/LSDDebugParams.cfg
+++ b/lsd_slam_core/cfg/LSDDebugParams.cfg
@@ -8,8 +8,8 @@ from dynamic_reconfigure.parameter_generator import *
 
 gen = ParameterGenerator()
 
-gen.add("plotStereoImages", bool_t, 0, "Plot Searched Stereo Lines, and color-coded stereo-results. Nice Visualization of what's going on, however drastically decreases mapping speed.", False)
-gen.add("plotTracking", bool_t, 0, "Plot final tracking residual. Nice Visualization of what's going on, however drastically decreases tracking speed.", False)
+gen.add("plotStereoImages", bool_t, 0, "Plot Searched Stereo Lines, and color-coded stereo-results. Nice Visualization of what`s going on, however drastically decreases mapping speed.", False)
+gen.add("plotTracking", bool_t, 0, "Plot final tracking residual. Nice Visualization of what`s going on, however drastically decreases tracking speed.", False)
 
 
 #debug parameters
@@ -45,7 +45,7 @@ gen.add("printConstraintSearchInfo", bool_t, 0, "print lots of debug information
 gen.add("printOptimizationInfo", bool_t, 0, "print lots of debug information", False)
 gen.add("printRelocalizationInfo", bool_t, 0, "print lots of debug information", False)
 
-gen.add("continuousPCOutput", bool_t, 0, "Publish Current Keyframe's Pointcloud after each update, to be seen in the viewer. Nice Visualization, however bad for performance and bandwith. ", False)
+gen.add("continuousPCOutput", bool_t, 0, "Publish Current Keyframe`s Pointcloud after each update, to be seen in the viewer. Nice Visualization, however bad for performance and bandwith. ", False)
 
 
 # result save control

--- a/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
+++ b/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
@@ -17,11 +17,11 @@ gen.add("showCurrentPointcloud", bool_t, 0, "Toggle Drawing of the latest pointc
 
 gen.add("pointTesselation", double_t, 0, "Size of Points", 1, 0.0, 5)
 gen.add("lineTesselation", double_t, 0, "Width of Lines", 1, 0.0, 5)
-gen.add("scaledDepthVarTH", double_t, 0, "log10 of threshold on point's variance, in the respective keyframe's scale. ", -3, -10, 1)
-gen.add("absDepthVarTH", double_t, 0, "log10 of threshold on point's variance, in absolute scale.", -1, -10, 1)
+gen.add("scaledDepthVarTH", double_t, 0, "log10 of threshold on point`s variance, in the respective keyframe`s scale. ", -3, -10, 1)
+gen.add("absDepthVarTH", double_t, 0, "log10 of threshold on point`s variance, in absolute scale.", -1, -10, 1)
 gen.add("minNearSupport", int_t, 0, "only plot points that have #minNearSupport similar neighbours (higher values remove outliers)", 7, 0, 9)
 
-gen.add("cutFirstNKf", int_t, 0, "do not display the first #cutFirstNKf keyframe's pointclouds, to remove artifacts left-over from the random initialization.", 5, 0, 100)
+gen.add("cutFirstNKf", int_t, 0, "do not display the first #cutFirstNKf keyframe`s pointclouds, to remove artifacts left-over from the random initialization.", 5, 0, 100)
 
 gen.add("sparsifyFactor", int_t, 0, "only plot one out of #sparsifyFactor points, selected at random. Use this to significantly speed up rendering for large maps.", 1, 1, 100)
 


### PR DESCRIPTION
Change ' (single aposthrope symbol) to ` (backtick symbol) in installer configuration file to avoid errors while compiling and installing on ubuntu 14.04 system